### PR TITLE
Optionally support ring-cors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Current version of `aleph-middleware` depends on `[aleph "0.4.1"]` &
 
 Note that you don't have convert your normal responses to deferreds.
 
+## Other middlewares
+
+aleph-middleware also has support for other, "none core" middlewares. In order
+to use them, you need to add dependecies to your project. These are:
+
+- `aleph.middleware.cors` - add [ring-cors "0.1.10"] or greater
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,6 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[aleph "0.4.1"]
                  [org.clojure/clojure "1.8.0"]
-                 [ring/ring-core "1.5.0"]])
+                 [ring/ring-core "1.5.0"]]
+
+  :profiles {:dev {:dependencies [[ring-cors "0.1.10"]]}})

--- a/src/aleph/middleware/cors.clj
+++ b/src/aleph/middleware/cors.clj
@@ -1,0 +1,11 @@
+(ns aleph.middleware.cors
+  (:require [ring.middleware.cors :as cors]
+            [manifold.deferred :as d]))
+
+(defn- async-response-handler [request access-control response]
+  (d/chain' response #(cors/add-access-control request access-control %)))
+
+(defn wrap-cors [handler & access-control]
+  (let [access-control (cors/normalize-config access-control)]
+    (fn [request]
+      (cors/handle-cors handler request access-control async-response-handler))))


### PR DESCRIPTION
In reference to https://github.com/muhuk/aleph-middleware/issues/3.

How about this? The user has to add [ring-cors "0.1.10"] to their build or compilation will fail.